### PR TITLE
Removed you're vscode file from the REPO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 test
 src/**.js
 .idea/*
+.vscode/
 
 coverage
 .nyc_output


### PR DESCRIPTION
This is un-needed and clutters the REPO

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improves Githubs REPO Cleanup

* **What is the current behavior?** (You can also link to an open issue here)
Storing Vscode local file in the Github
* **What is the new behavior (if this is a feature change)?**
Nothing

* **Other information**:
N/A