### PR TITLE
Fixing event clock to fire events reliably

### DIFF
--- a/src/lib/room/Clock.ts
+++ b/src/lib/room/Clock.ts
@@ -1,0 +1,49 @@
+import Clock from '@gamestdio/timer'
+
+class InternalClock {
+  public loop: any
+  public clock: Clock
+
+  public handlers: Array<{ time: number; callback: () => any }> = []
+  constructor() {
+    this.clock = new Clock(false)
+    this.loop = setInterval(this.tickClock, 1000 / 60)
+  }
+
+  // Schedule an event to run at a certain date/time
+  public at = (date: Date, callback: () => any) => {
+    const eventTime = Math.round(date.getTime() / 1000)
+    const currentUnix = this.clock.currentTime / 1000
+
+    // Only keep track of events in the future
+    if (currentUnix < eventTime) {
+      this.handlers.push({
+        time: eventTime,
+        callback
+      })
+    }
+  }
+
+  public tickClock = () => {
+    // Tick the clock
+    this.clock.tick()
+
+    // Check and run any scheduled events
+    const currentTime = Math.round(this.clock.currentTime / 1000)
+
+    // Run the callback at the earliest possible time
+    // which could be at or after the specified time
+    this.handlers.forEach(handler => {
+      if (currentTime >= handler.time) {
+        handler.callback()
+      }
+    })
+
+    // Keep all the handlers that haven't run yet
+    this.handlers = this.handlers.filter(handler => currentTime < handler.time)
+  }
+
+  public dispose = () => clearInterval(this.loop)
+}
+
+export default InternalClock


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
An event scheduler that fires events scheduled to run at a certain time.

* **What is the current behavior?** (You can also link to an open issue here)
Scheduler was removed for performance reasons

* **What is the new behavior (if this is a feature change)?**
Original scheduler was too rigid and depended too much on exact timings which may or may not have worked depending on processor loads and other variables. This scheduler runs events as soon possible at or slightly after the scheduled time (since there's no guarantee the clock will tick exactly at the event's scheduled time).

* **Other information**:
Doesn't have to go out now, but leaving this here for future reference!